### PR TITLE
Fix to Ring Indicator Not Being Centered

### DIFF
--- a/Sources/SVProgressHUD/SVProgressHUD.swift
+++ b/Sources/SVProgressHUD/SVProgressHUD.swift
@@ -459,7 +459,7 @@ public class SVProgressHUD: UIView {
     var labelHeight: CGFloat = 0
     var labelWidth: CGFloat  = 0
     
-    if let slText = statusLabel.text {
+    if let slText = statusLabel.text, !slText.isEmpty {
       let constraintSize = CGSize(width: 200, height: 200)
       labelRect = slText.boundingRect(with: constraintSize,
                                       options: [.usesFontLeading, .truncatesLastVisibleLine, .usesLineFragmentOrigin],
@@ -489,7 +489,7 @@ public class SVProgressHUD: UIView {
     
     // |-spacing-content-(labelSpacing-label-)spacing-|
     hudHeight = Self.SVProgressHUDVerticalSpacing + labelHeight + contentHeight + Self.SVProgressHUDVerticalSpacing
-    if statusLabel.text != nil && (imageUsed || progressUsed) {
+    if hasStatusText && (imageUsed || progressUsed) {
       // Add spacing if both content and label are used
       hudHeight += Self.SVProgressHUDLabelSpacing
     }
@@ -504,7 +504,7 @@ public class SVProgressHUD: UIView {
     
     // Spinner and image view
     var centerY: CGFloat = 0
-    if statusLabel.text != nil {
+    if hasStatusText {
       let yOffset: CGFloat = [Self.SVProgressHUDVerticalSpacing, (minimumSize.height - contentHeight - Self.SVProgressHUDLabelSpacing - labelHeight) / 2].theMax()
       centerY = yOffset + contentHeight / 2
     } else {
@@ -597,7 +597,7 @@ public class SVProgressHUD: UIView {
   }
   
   var notificationUserInfo: [String: String]? {
-    if let text = statusLabel.text {
+    if let text = statusLabel.text, !text.isEmpty {
       return [SVProgressHUDStatusUserInfoKey: text]
     }
     return nil
@@ -1042,7 +1042,7 @@ public class SVProgressHUD: UIView {
       if let ind = internalIndefiniteAnimatedView as? SVIndefiniteAnimatedView {
         ind.strokeColor = foregroundImageColorForStyle ?? ind.strokeColor
         ind.strokeThickness = ringThickness
-        ind.radius = statusLabel.text != nil ? ringRadius : ringNoTextRadius
+        ind.radius = hasStatusText ? ringRadius : ringNoTextRadius
       }
       
     } else {
@@ -1070,7 +1070,7 @@ public class SVProgressHUD: UIView {
     // Update styling
     internalRingView.strokeColor = foregroundImageColorForStyle ?? internalRingView.strokeColor
     internalRingView.strokeThickness = ringThickness
-    internalRingView.radius = statusLabel.text != nil ? ringRadius : ringNoTextRadius
+    internalRingView.radius = hasStatusText ? ringRadius : ringNoTextRadius
     return internalRingView
   }
   
@@ -1078,7 +1078,7 @@ public class SVProgressHUD: UIView {
     // Update styling
     internalBackgroundRingView.strokeColor = foregroundImageColorForStyle?.withAlphaComponent(0.1) ?? internalBackgroundRingView.strokeColor
     internalBackgroundRingView.strokeThickness = ringThickness
-    internalBackgroundRingView.radius = statusLabel.text != nil ? ringRadius : ringNoTextRadius
+    internalBackgroundRingView.radius = hasStatusText ? ringRadius : ringNoTextRadius
     return internalBackgroundRingView
   }
   
@@ -1099,8 +1099,12 @@ public class SVProgressHUD: UIView {
   
   // MARK: - Utilities
   
-  static func isVisible() -> Bool {
+  public static func isVisible() -> Bool {
     return Self.sharedView.backgroundView.alpha > 0
+  }
+
+  private var hasStatusText: Bool {
+    statusLabel.text != nil && statusLabel.text?.isEmpty == false
   }
   
   // MARK: - Getters


### PR DESCRIPTION
## Description

This PR addresses an issue where the loading indicator ring was not appropriately centered due to unexpected values in the `statusLabel`'s `text` property. In some cases, the code was comparing the label's text to `nil`; instead, an empty string was assigned to the property.

To fix this issue, we have updated the code to check for both nil and empty string values in the `statusLabel` property. This ensures that the loading indicator ring is always centered correctly regardless of the label's content.

# Screenshots

| Before the Fix | After the Fix |
| -- | -- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-03-12 at 19 56 26](https://user-images.githubusercontent.com/89834420/224543764-64bbe5ff-1082-4687-bfde-4cd545d95674.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-03-12 at 20 12 29](https://user-images.githubusercontent.com/89834420/224544161-28d24668-9e2c-478e-947c-831a7ce9d658.png) |
